### PR TITLE
Add cleanup_all_data for manually clean data when game ends

### DIFF
--- a/addons/scene_safe_multiplayer/scene_safe_mp_manager.gd
+++ b/addons/scene_safe_multiplayer/scene_safe_mp_manager.gd
@@ -33,6 +33,7 @@ var synchronizer_map = {};
 ## in all of the maps, especially from any linked_synchronizers.
 func _ready():
 	multiplayer.peer_disconnected.connect(_cleanup_peer_data);
+	multiplayer.server_disconnected.connect(cleanup_all_data);
 
 
 ## This method is only intended to be called by a SceneSafeMpSpawner that has entered the tree.
@@ -167,6 +168,13 @@ func _cleanup_peer_data(peer: int):
 		synchronizer_map[key].confirmed_peers.erase(peer);
 		if synchronizer_map[key].confirmed_peers.size() == 0:
 			synchronizer_map.erase(key);
+
+
+## Clean up all data from all of the confirmed peers lists.
+func cleanup_all_data():
+	spawner_map = {}
+	
+	synchronizer_map = {}
 
 
 @rpc("any_peer", "call_local", "reliable")


### PR DESCRIPTION
There's an issue when a game is ended and a new one is started, data from the previous game remains.
When the new game starts, spawners are triggered with the old peers from the previous game.

This was an issue when the server ends the game, both on the server peer and the rest of the peers (that's also why it's now called on server_disconnected).

With the new cleanup_all_data method we can call it manually when the game ends to clean that data.